### PR TITLE
Fix suscriberCount.simpleText crashing library when it's undefined

### DIFF
--- a/src/classes/Channel/ChannelParser.ts
+++ b/src/classes/Channel/ChannelParser.ts
@@ -18,7 +18,7 @@ export class ChannelParser {
 		target.name = title;
 		target.thumbnails = new Thumbnails().load(avatar.thumbnails);
 		target.videoCount = 0; // data not available
-		target.subscriberCount = subscriberCountText.simpleText;
+		target.subscriberCount = subscriberCountText?.simpleText;
 
 		const { tvBanner, mobileBanner, banner } = data.header.c4TabbedHeaderRenderer;
 


### PR DESCRIPTION
If a channel has suscriberCount hidden (like topic channels do); the property  `subscriberCountText.simpleText` is not accessible which leads to a crash. the interrogation mark fixes this issue