### PR TITLE
Fix tabRenderer.content crashing library when it's undefined

### DIFF
--- a/src/classes/BaseChannel/BaseChannelParser.ts
+++ b/src/classes/BaseChannel/BaseChannelParser.ts
@@ -19,7 +19,7 @@ export class BaseChannelParser {
 	static parseTabData(name: "videos" | "playlists", data: YoutubeRawData): YoutubeRawData {
 		const index = name === "videos" ? 1 : 2;
 		return (
-			data.contents?.twoColumnBrowseResultsRenderer.tabs[index].tabRenderer.content
+			data.contents?.twoColumnBrowseResultsRenderer.tabs[index].tabRenderer.content?
 				.sectionListRenderer.contents[0].itemSectionRenderer.contents[0].gridRenderer
 				?.items ||
 			data.onResponseReceivedActions?.[0].appendContinuationItemsAction.continuationItems ||


### PR DESCRIPTION
I don't know when this happens but `tabRenderer.content ` is sometimes not accessible which leads to a crash. the interrogation mark fixes this issue