### PR TITLE
Fix documentation error of thumbnails.best

### DIFF
--- a/src/classes/Thumbnails/Thumbnails.ts
+++ b/src/classes/Thumbnails/Thumbnails.ts
@@ -37,7 +37,7 @@ export class Thumbnails extends Array<Thumbnail> {
 	 *
 	 * @example
 	 * ```js
-	 * const min = video.thumbnails.min;
+	 * const best = video.thumbnails.best;
 	 * ```
 	 */
 	get best(): string | undefined {


### PR DESCRIPTION
There is a documentation error with the wrong getter being used in the example.