### PR TITLE
fix crawling likeCount throws error

### DIFF
--- a/src/classes/BaseVideo/BaseVideoParser.ts
+++ b/src/classes/BaseVideo/BaseVideoParser.ts
@@ -31,7 +31,7 @@ export class BaseVideoParser {
 
 		// Like Count and Dislike Count
 		const topLevelButtons = videoInfo.videoActions.menuRenderer.topLevelButtons;
-		target.likeCount = stripToInt(BaseVideoParser.parseButtonRenderer(topLevelButtons[0]));
+		target.likeCount = stripToInt(BaseVideoParser.parseButtonRenderer(topLevelButtons[0].segmentedLikeDislikeButtonRenderer.likeButton));
 
 		// Tags and description
 		target.tags =


### PR DESCRIPTION
**Problem**
`defaultText` not found when crawling videos.

```
const video = await youtube.getVideo("ERumF8gI_pE");
```

```
/Users/my/path/youtubei/src/classes/BaseVideo/BaseVideoParser.ts:118
                        buttonRenderer.defaultText?.accessibility || buttonRenderer.accessibilityData
                                       ^

TypeError: Cannot read properties of undefined (reading 'defaultText')
    at Function.parseButtonRenderer (/Users/my/path/youtubei/src/classes/BaseVideo/BaseVideoParser.ts:118:19)
    at Function.loadBaseVideo (/Users/my/path/youtubei/src/classes/BaseVideo/BaseVideoParser.ts:39:49)
    at Video.load (/Users/my/path/youtubei/src/classes/BaseVideo/BaseVideo.ts:71:19)
    at Video.load (/Users/my/path/youtubei/src/classes/Video/Video.ts:44:9)
    at Client.getVideo (/Users/my/path/youtubei/src/classes/Client/Client.ts:108:34)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at run (/Users/my/path/youtubei/src/index.ts:8:19)
```

**Solution**

Check the json data of crawling and submit this PR.