### PR TITLE
Protobuf implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
 	"homepage": "https://suspiciouslookingowl.github.io/youtubei",
 	"dependencies": {
 		"node-fetch": "2.6.7",
-		"protocol-buffers": "5.0.0"
+		"protobufjs": "7.2.4"
 	}
 }

--- a/src/youtube/Client/Client.ts
+++ b/src/youtube/Client/Client.ts
@@ -130,7 +130,7 @@ export class Client {
 	}
 
 	async getVideoTranscript(videoId: string): Promise<Transcript[] | undefined> {
-		const bufferParams = TranscriptParamsProto.TranscriptParams.encode({ videoId });
+		const bufferParams = TranscriptParamsProto.encode({ videoId }).finish();
 		const response = await this.http.post(`${I_END_POINT}/get_transcript`, {
 			data: { params: Buffer.from(bufferParams).toString("base64") },
 		});

--- a/src/youtube/SearchResult/SearchResult.ts
+++ b/src/youtube/SearchResult/SearchResult.ts
@@ -138,7 +138,7 @@ export class SearchResult<T extends SearchType | undefined = "all"> extends Cont
 		this.items = [];
 		this.estimatedResults = 0;
 
-		const bufferParams = SearchProto.SearchOptions.encode(optionsToProto(options));
+		const bufferParams = SearchProto.encode(optionsToProto(options)).finish();
 
 		const response = await this.client.http.post(`${I_END_POINT}/search`, {
 			data: {

--- a/src/youtube/SearchResult/proto/index.ts
+++ b/src/youtube/SearchResult/proto/index.ts
@@ -1,4 +1,4 @@
-import proto from "protocol-buffers";
+import protobuf from "protobufjs";
 
 import {
 	SearchDuration,
@@ -11,7 +11,7 @@ import {
 import { SearchProto as ProtoType } from "./SearchProto";
 
 // TODO move this to .proto file
-export const SearchProto = proto<ProtoType>(`
+export const SearchProto = protobuf.parse(`
 	message SearchOptions {
 		message Options {
 			optional int32 uploadDate = 1;
@@ -21,8 +21,8 @@ export const SearchProto = proto<ProtoType>(`
 			optional int32 subtitles = 5;
 			optional int32 creativeCommons = 6;
 			optional int32 live = 8;
-			optional int32 4k = 14;
-			optional int32 360 = 15;
+			optional int32 _4k = 14;
+			optional int32 _360 = 15;
 			optional int32 location = 23;
 			optional int32 hdr = 25;
 			optional int32 vr180 = 26;
@@ -31,7 +31,7 @@ export const SearchProto = proto<ProtoType>(`
 		optional int32 sortBy = 1;
 		optional Options options = 2;
 	}
-`);
+`).root.lookupType("SearchOptions");
 
 const searchUploadDateProto: Record<SearchUploadDate, number> = {
 	all: 0,

--- a/src/youtube/Transcript/proto/TranscriptParamsProto.ts
+++ b/src/youtube/Transcript/proto/TranscriptParamsProto.ts
@@ -1,4 +1,4 @@
-import proto from "protocol-buffers";
+import protobuf from "protobufjs";
 
 export type TranscriptParams = {
 	TranscriptParams: {
@@ -6,8 +6,8 @@ export type TranscriptParams = {
 	};
 };
 
-export const TranscriptParamsProto = proto<TranscriptParams>(`
+export const TranscriptParamsProto = protobuf.parse<TranscriptParams>(`
 	message TranscriptParams {
 		optional string videoId = 1;
 	}
-`);
+`).root.lookupType("TranscriptParams");

--- a/src/youtube/Transcript/proto/TranscriptParamsProto.ts
+++ b/src/youtube/Transcript/proto/TranscriptParamsProto.ts
@@ -6,7 +6,7 @@ export type TranscriptParams = {
 	};
 };
 
-export const TranscriptParamsProto = protobuf.parse<TranscriptParams>(`
+export const TranscriptParamsProto = protobuf.parse(`
 	message TranscriptParams {
 		optional string videoId = 1;
 	}


### PR DESCRIPTION
This will use [Protobuf](https://www.npmjs.com/package/protobufjs) instead of protocol-buffers

This change means less dependencies since protobuf is a native js/ts implementation and also better support for stuff like react-native which doesn't have the native packages required to run protocol-buffers

I had to change the proto definitions a bit since for stuff like `4k` and `360` since names have to beginn with a letter or "_".
I run all tests and every test passed so everything should work just fine.