### PR TITLE
Fixed error for video without title

### DIFF
--- a/src/youtube/VideoCompact/VideoCompactParser.ts
+++ b/src/youtube/VideoCompact/VideoCompactParser.ts
@@ -21,7 +21,7 @@ export class VideoCompactParser {
 		} = data;
 
 		target.id = videoId;
-		target.title = headline ? headline.simpleText : title.simpleText || title.runs[0]?.text;
+		target.title = headline ? headline.simpleText : title.simpleText || title.runs?.[0]?.text;
 		target.thumbnails = new Thumbnails().load(thumbnail.thumbnails);
 		target.uploadDate = publishedTimeText?.simpleText;
 		target.description =


### PR DESCRIPTION
I recently found a video with a parse error and checked it and found that the video title does not exist.
example: https://www.youtube.com/watch?v=gOOeVTyRiRE