### PR TITLE
fix: alternative channel parsing without banners

### DIFF
--- a/src/youtube/Channel/ChannelParser.ts
+++ b/src/youtube/Channel/ChannelParser.ts
@@ -27,13 +27,12 @@ export class ChannelParser {
 			const {
 				metadata,
 				image: imageModel,
-				banner: bannerModel,
 			} = pageHeaderRenderer.content.pageHeaderViewModel;
 
 			subscriberCountText =
 				metadata.contentMetadataViewModel.metadataRows[1].metadataParts[0].text.content;
 			avatar = imageModel.decoratedAvatarViewModel.avatar.avatarViewModel.image.sources;
-			banner = bannerModel.imageBannerViewModel.image.sources;
+			banner = pageHeaderRenderer.content.pageHeaderViewModel?.bannerModel?.imageBannerViewModel?.image?.sources;
 		}
 
 		target.id = channelId;


### PR DESCRIPTION
Fixes: https://github.com/SuspiciousLookingOwl/youtubei/issues/101

For alternative channel parsing, when trying to parse a channel with no banners it fails due to undefined banner variable.