### PR TITLE
feat: add isShorts property to videoCompact.

### DIFF
--- a/src/youtube/VideoCompact/VideoCompact.ts
+++ b/src/youtube/VideoCompact/VideoCompact.ts
@@ -31,6 +31,8 @@ export class VideoCompact extends Base implements VideoCompactProperties {
 	duration!: number | null;
 	/** Whether this video is a live now or not */
 	isLive!: boolean;
+	/** Whether this video is a shorts or not */
+	isShorts!: boolean;
 	/** The channel who uploads this video */
 	channel?: BaseChannel;
 	/** The date this video is uploaded at */

--- a/src/youtube/VideoCompact/VideoCompactParser.ts
+++ b/src/youtube/VideoCompact/VideoCompactParser.ts
@@ -42,6 +42,9 @@ export class VideoCompactParser {
 			!!(badges?.[0].metadataBadgeRenderer.style === "BADGE_STYLE_TYPE_LIVE_NOW") ||
 			thumbnailOverlays?.[0].thumbnailOverlayTimeStatusRenderer?.style === "LIVE";
 
+		target.isShorts =
+			thumbnailOverlays?.[0].thumbnailOverlayTimeStatusRenderer?.style === "SHORTS" || false;
+
 		// Channel
 		const browseEndpoint = (ownerText || shortBylineText)?.runs[0]?.navigationEndpoint
 			?.browseEndpoint;


### PR DESCRIPTION
Greeting, friend! 

As "Shorts" becomes a popular video type on youtube, it seems that it's useful to figure out if a video is a shorts video or not.

I've found that `isLive` property reads a field `thumbnailOverlayTimeStatusRenderer.style`. And developer of youtube also use this field to tag a `SHORTS' on the cover of video. So I think it's reliable to use this field to judge if a video is `Shorts`.

Thanks to your review.