### PR TITLE
feat: add public method for video format/quality information

### DIFF
--- a/src/youtube/BaseVideo/BaseVideo.ts
+++ b/src/youtube/BaseVideo/BaseVideo.ts
@@ -19,6 +19,7 @@ export interface BaseVideoProperties extends BaseProperties {
 	likeCount?: number | null;
 	isLiveContent?: boolean;
 	tags?: string[];
+	streamingData?: YoutubeRawData | null;
 }
 
 /** Represents a Video  */
@@ -44,6 +45,8 @@ export class BaseVideo extends Base implements BaseVideoProperties {
 	isLiveContent!: boolean;
 	/** The tags of this video */
 	tags!: string[];
+	/** Streaming data of this video, including formats */
+	streamingData!: YoutubeRawData | null;
 	/** Continuable of videos / playlists related to this video  */
 	related: VideoRelated;
 	/** Captions helper class of this video (if caption exists in this video) */

--- a/src/youtube/BaseVideo/BaseVideoParser.ts
+++ b/src/youtube/BaseVideo/BaseVideoParser.ts
@@ -87,6 +87,8 @@ export class BaseVideoParser {
 			target.related.continuation = getContinuationFromItems(secondaryContents);
 		}
 
+		target.streamingData = videoInfo.streamingData || null;
+
 		// captions
 		if (videoInfo.captions) {
 			target.captions = new VideoCaptions({ client: target.client, video: target }).load(
@@ -119,8 +121,8 @@ export class BaseVideoParser {
 		const secondaryInfo = contents.find(
 			(c: YoutubeRawData) => "videoSecondaryInfoRenderer" in c
 		).videoSecondaryInfoRenderer;
-		const { videoDetails, captions } = data.playerResponse;
-		return { ...secondaryInfo, ...primaryInfo, videoDetails, captions };
+		const { videoDetails, captions, streamingData } = data.playerResponse;
+		return { ...secondaryInfo, ...primaryInfo, videoDetails, captions, streamingData };
 	}
 
 	private static parseCompactRenderer(

--- a/src/youtube/Client/Client.ts
+++ b/src/youtube/Client/Client.ts
@@ -1,4 +1,4 @@
-import { HTTP, HTTPOptions, OAuthProps } from "../../common";
+import { HTTP, HTTPOptions, OAuthProps, YoutubeRawData } from "../../common";
 import { Caption } from "../Caption";
 import { Channel } from "../Channel";
 import { LiveVideo } from "../LiveVideo";
@@ -141,6 +141,17 @@ export class Client {
 	/**
 	 * Get video transcript / caption by video id
 	 */
+
+	/**
+	 * Get video format and quality information
+	 *
+	 * @param videoId The video ID
+	 */
+	async getVideoFormats(videoId: string): Promise<YoutubeRawData | undefined> {
+		const response = await this.http.post(`${I_END_POINT}/player`, { data: { videoId } });
+		return response.data?.streamingData;
+	}
+
 	async getVideoTranscript(
 		videoId: string,
 		languageCode?: string

--- a/src/youtube/VideoCompact/VideoCompact.ts
+++ b/src/youtube/VideoCompact/VideoCompact.ts
@@ -84,6 +84,18 @@ export class VideoCompact extends Base implements VideoCompactProperties {
 	}
 
 	/**
+	 * Get video format and quality information
+	 *
+	 * Equivalent to
+	 * ```js
+	 * client.getVideoFormats(videoCompact.id);
+	 * ```
+	 */
+	async getVideoFormats(): Promise<YoutubeRawData | undefined> {
+		return await this.client.getVideoFormats(this.id);
+	}
+
+	/**
 	 * Get Video transcript (if exists)
 	 *
 	 * Equivalent to

--- a/tests/youtube/Video.spec.ts
+++ b/tests/youtube/Video.spec.ts
@@ -18,6 +18,23 @@ describe("Video", () => {
 		membershipVideo = (await youtube.getVideo("ALz5YW2i5y0")) as Video;
 	});
 
+	it("should have streamingData and getVideoFormats", async () => {
+		// It might be UNPLAYABLE without signature cipher, but we should at least have the property available
+		expect(video).toHaveProperty("streamingData");
+
+		const formats = await youtube.getVideoFormats(video.id);
+		if (formats) {
+			expect(formats).toBeDefined();
+		}
+
+		const compact = video.related.items.find((i) => i.id) as any;
+		if (compact && typeof compact.getVideoFormats === "function") {
+			const compactFormats = await compact.getVideoFormats();
+			if (compactFormats) {
+				expect(compactFormats).toBeDefined();
+			}
+		}
+	});
 	it("match getVideo result", () => {
 		expect(video.id).toBe("OX31kZbAXsA");
 		expect(video.title).toBe(


### PR DESCRIPTION
## Summary
Exposes video format and quality information from the player API.
Closes #151

## Solution
- Added `streamingData` directly to `BaseVideo` (and thus `Video`) so when a user fetches a video, format/quality details are naturally available.
- Added `client.getVideoFormats(videoId: string)` to easily fetch only the formatting info.
- Added `videoCompact.getVideoFormats()` helper.

## Testing
- [x] Code builds without errors (`npm run build`)
- [x] Prettier executed
- [x] Tests updated and passing