### PR TITLE
feat(types): expose formats and adaptiveFormats in BaseVideo properties

### DIFF
--- a/src/youtube/BaseVideo/BaseVideo.ts
+++ b/src/youtube/BaseVideo/BaseVideo.ts
@@ -19,6 +19,9 @@ export interface BaseVideoProperties extends BaseProperties {
 	likeCount?: number | null;
 	isLiveContent?: boolean;
 	tags?: string[];
+	formats?: YoutubeRawData[];
+	adaptiveFormats?: YoutubeRawData[];
+
 }
 
 /** Represents a Video  */
@@ -43,6 +46,11 @@ export class BaseVideo extends Base implements BaseVideoProperties {
 	/** Whether this video is a live content or not */
 	isLiveContent!: boolean;
 	/** The tags of this video */
+	/** The formats of the video */
+	formats!: YoutubeRawData[];
+	/** The adaptive formats of the video */
+	adaptiveFormats!: YoutubeRawData[];
+
 	tags!: string[];
 	/** Continuable of videos / playlists related to this video  */
 	related: VideoRelated;

--- a/src/youtube/BaseVideo/BaseVideoParser.ts
+++ b/src/youtube/BaseVideo/BaseVideoParser.ts
@@ -16,6 +16,9 @@ export class BaseVideoParser {
 		target.uploadDate = videoInfo.dateText.simpleText;
 		target.viewCount = +videoInfo.videoDetails.viewCount || null;
 		target.isLiveContent = videoInfo.videoDetails.isLiveContent;
+		target.formats = videoInfo.streamingData?.formats || [];
+		target.adaptiveFormats = videoInfo.streamingData?.adaptiveFormats || [];
+
 		target.thumbnails = new Thumbnails().load(videoInfo.videoDetails.thumbnail.thumbnails);
 
 		// Channel
@@ -119,8 +122,8 @@ export class BaseVideoParser {
 		const secondaryInfo = contents.find(
 			(c: YoutubeRawData) => "videoSecondaryInfoRenderer" in c
 		).videoSecondaryInfoRenderer;
-		const { videoDetails, captions } = data.playerResponse;
-		return { ...secondaryInfo, ...primaryInfo, videoDetails, captions };
+		const { videoDetails, captions, streamingData } = data.playerResponse;
+		return { ...secondaryInfo, ...primaryInfo, videoDetails, captions, streamingData };
 	}
 
 	private static parseCompactRenderer(


### PR DESCRIPTION
## Summary
Extracted `formats` and `adaptiveFormats` from the inner `playerResponse.streamingData` and exposed them on `BaseVideo` (and `Video` / `LiveVideo`).

## Problem
Closes #151 
Format data was accessible only via direct HTTP call to `/player` endpoint. The user requested to expose this information via the library directly.

## Solution
During `getVideo` parsing (`BaseVideoParser.loadBaseVideo`), the library already fetches `playerResponse`. We just need to attach the `streamingData.formats` and `streamingData.adaptiveFormats` to the returned `Video` object.

## Testing
- Built successfully: `pnpm run build`
- All tests pass (aside from a pre-existing failed test on `development` branch)

## Checklist
- [x] Code builds without errors
- [x] Dependencies added to package.json (N/A)