### PR TITLE
fix: support lockupViewModel in channel live/videos tabs

### DIFF
--- a/src/youtube/BaseChannel/ChannelLive.ts
+++ b/src/youtube/BaseChannel/ChannelLive.ts
@@ -1,4 +1,4 @@
-import { YoutubeRawData, getContinuationFromItems, mapFilter } from "../../common";
+import { YoutubeRawData, Thumbnails, getContinuationFromItems, getDuration, mapFilter, stripToInt } from "../../common";
 import { Continuable, ContinuableConstructorParams, FetchResult } from "../Continuable";
 import { VideoCompact } from "../VideoCompact";
 import { I_END_POINT } from "../constants";
@@ -44,13 +44,36 @@ export class ChannelLive extends Continuable<VideoCompact> {
 
 		const items = BaseChannelParser.parseTabData("live", response.data);
 		const continuation = getContinuationFromItems(items);
-		const data = mapFilter(items, "videoRenderer");
+
+		const videoRenderers = mapFilter(items, "videoRenderer");
+		const lockupViewModels = mapFilter(items, "lockupViewModel");
+
+		const fromVideoRenderer = videoRenderers.map((i: YoutubeRawData) =>
+			new VideoCompact({ client: this.client, channel: this.channel }).load(i)
+		);
+
+		const fromLockup = lockupViewModels.map((i: YoutubeRawData) => {
+			const v = new VideoCompact({ client: this.client, channel: this.channel });
+			v.id = i.contentId;
+			v.title = i.metadata?.lockupMetadataViewModel?.title?.content;
+			v.thumbnails = new Thumbnails().load(i.contentImage?.thumbnailViewModel?.image?.sources || []);
+
+			const overlays = i.contentImage?.thumbnailViewModel?.overlays?.[0] || {};
+			const badges = overlays.thumbnailBottomOverlayViewModel?.badges || [];
+			const badgeText = badges[0]?.thumbnailBadgeViewModel?.text || "";
+			v.isLive = badgeText === "LIVE";
+			v.duration = !v.isLive && badgeText ? getDuration(badgeText) : null;
+
+			const metaRows = i.metadata?.lockupMetadataViewModel?.metadata?.contentMetadataViewModel?.metadataRows || [];
+			const metaText = metaRows[0]?.metadataParts?.[0]?.text?.content || "";
+			v.viewCount = stripToInt(metaText);
+
+			return v;
+		});
 
 		return {
 			continuation,
-			items: data.map((i: YoutubeRawData) =>
-				new VideoCompact({ client: this.client, channel: this.channel }).load(i)
-			),
+			items: [...fromVideoRenderer, ...fromLockup],
 		};
 	}
 }

--- a/src/youtube/BaseChannel/ChannelVideos.ts
+++ b/src/youtube/BaseChannel/ChannelVideos.ts
@@ -1,4 +1,4 @@
-import { getContinuationFromItems, mapFilter, YoutubeRawData } from "../../common";
+import { getContinuationFromItems, getDuration, mapFilter, stripToInt, Thumbnails, YoutubeRawData } from "../../common";
 import { Continuable, ContinuableConstructorParams, FetchResult } from "../Continuable";
 import { VideoCompact } from "../VideoCompact";
 import { I_END_POINT } from "../constants";
@@ -44,13 +44,36 @@ export class ChannelVideos extends Continuable<VideoCompact> {
 
 		const items = BaseChannelParser.parseTabData("videos", response.data);
 		const continuation = getContinuationFromItems(items);
-		const data = mapFilter(items, "videoRenderer");
+
+		const videoRenderers = mapFilter(items, "videoRenderer");
+		const lockupViewModels = mapFilter(items, "lockupViewModel");
+
+		const fromVideoRenderer = videoRenderers.map((i: YoutubeRawData) =>
+			new VideoCompact({ client: this.client, channel: this.channel }).load(i)
+		);
+
+		const fromLockup = lockupViewModels.map((i: YoutubeRawData) => {
+			const v = new VideoCompact({ client: this.client, channel: this.channel });
+			v.id = i.contentId;
+			v.title = i.metadata?.lockupMetadataViewModel?.title?.content;
+			v.thumbnails = new Thumbnails().load(i.contentImage?.thumbnailViewModel?.image?.sources || []);
+
+			const overlays = i.contentImage?.thumbnailViewModel?.overlays?.[0] || {};
+			const badges = overlays.thumbnailBottomOverlayViewModel?.badges || [];
+			const badgeText = badges[0]?.thumbnailBadgeViewModel?.text || "";
+			v.isLive = badgeText === "LIVE";
+			v.duration = !v.isLive && badgeText ? getDuration(badgeText) : null;
+
+			const metaRows = i.metadata?.lockupMetadataViewModel?.metadata?.contentMetadataViewModel?.metadataRows || [];
+			const metaText = metaRows[0]?.metadataParts?.[0]?.text?.content || "";
+			v.viewCount = stripToInt(metaText);
+
+			return v;
+		});
 
 		return {
 			continuation,
-			items: data.map((i: YoutubeRawData) =>
-				new VideoCompact({ client: this.client, channel: this.channel }).load(i)
-			),
+			items: [...fromVideoRenderer, ...fromLockup],
 		};
 	}
 }


### PR DESCRIPTION
## Summary

YouTube recently changed the data structure returned for channel live and video tabs. Items that previously used `videoRenderer` now use `lockupViewModel`, which causes `mapFilter(items, "videoRenderer")` to silently return 0 results for all channels.

- **`ChannelLive.ts`** and **`ChannelVideos.ts`** now handle both `videoRenderer` and `lockupViewModel` items
- The existing `loadLockupVideoCompact` in `VideoCompactParser` expects fields (`decoratedAvatarViewModel`) not present in channel tab context, so the lockup parsing is done inline with the simpler channel-tab structure
- Backwards compatible — still handles `videoRenderer` if YouTube serves it

## What changed

`ChannelLive.ts` / `ChannelVideos.ts` `fetch()`:

```ts
// Before
const data = mapFilter(items, "videoRenderer");

// After  
const videoRenderers = mapFilter(items, "videoRenderer");
const lockupViewModels = mapFilter(items, "lockupViewModel");
// ... handles both formats
```

## Channel tab `lockupViewModel` structure

```
lockupViewModel
├── contentId                          → video ID
├── contentImage.thumbnailViewModel
│   ├── image.sources                  → thumbnails
│   └── overlays[0]...badges[0]
│       └── thumbnailBadgeViewModel.text → "LIVE" or duration
└── metadata.lockupMetadataViewModel
    ├── title.content                  → video title
    └── metadata...metadataRows[0]
        └── metadataParts[0].text.content → "73 watching"
```

Note: this differs from search-result lockups which include `decoratedAvatarViewModel` and have channel info in `metadataRows[0]`.

## Test plan

- [x] Tested with multiple live channels (IndiaTV, NDTV, Aaj Tak, Zee News, etc.)
- [x] Verified `isLive`, `viewCount`, `title`, `id`, `thumbnails` all populate correctly
- [x] Verified non-live items (upcoming, past streams) are parsed with correct duration
- [x] Running in production scraping 54 channels every minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)