### PR TITLE
fix captions not being parsed

### DIFF
--- a/src/common/shared/HTTP/HTTP.ts
+++ b/src/common/shared/HTTP/HTTP.ts
@@ -25,6 +25,8 @@ export type HTTPOptions = {
 	baseUrl: string;
 	clientName: string;
 	clientVersion: string;
+	playerClientName?: string;
+	playerClientVersion?: string;
 	fetchOptions?: Partial<RequestInit>;
 	youtubeClientOptions?: Record<string, unknown>;
 	initialCookie?: string;
@@ -51,6 +53,8 @@ export class HTTP {
 	private baseUrl: string;
 	private clientName: string;
 	private clientVersion: string;
+	private playerClientName?: string;
+	private playerClientVersion?: string;
 	private cookie: string;
 	private defaultHeaders: HeadersInit;
 	private defaultFetchOptions: Partial<RequestInit>;
@@ -65,6 +69,8 @@ export class HTTP {
 		this.baseUrl = options.baseUrl;
 		this.clientName = options.clientName;
 		this.clientVersion = options.clientVersion;
+		this.playerClientName = options.playerClientName;
+		this.playerClientVersion = options.playerClientVersion;
 		this.cookie = options.initialCookie || "";
 		this.defaultHeaders = {
 			"x-youtube-client-version": this.clientVersion,
@@ -94,6 +100,9 @@ export class HTTP {
 	}
 
 	async post(path: string, options?: Partial<Options>): Promise<Response> {
+		// a proof of origin token makes the default client acceptable to `/player`
+		const usePlayerClient = this.isPlayerEndpoint(path) && !this.pot;
+
 		return await this.request(path, {
 			...options,
 			method: "POST",
@@ -105,8 +114,9 @@ export class HTTP {
 			data: {
 				context: {
 					client: {
-						clientName: this.clientName,
-						clientVersion: this.clientVersion,
+						clientName: (usePlayerClient && this.playerClientName) || this.clientName,
+						clientVersion:
+							(usePlayerClient && this.playerClientVersion) || this.clientVersion,
 						visitorData: this.pot?.visitorData,
 						...this.defaultClientOptions,
 					},
@@ -117,10 +127,13 @@ export class HTTP {
 		});
 	}
 
+	private isPlayerEndpoint(path: string): boolean {
+		const url = path.startsWith("http") ? path : `https://${this.baseUrl}/${path}`;
+		return new URL(url).pathname.endsWith("/player");
+	}
+
 	private async request(path: string, partialOptions: Partial<Options>): Promise<Response> {
-		const requiresAuth = new URL(`https://${this.baseUrl}/${path}`).pathname.endsWith(
-			"/player"
-		);
+		const requiresAuth = this.isPlayerEndpoint(path);
 
 		if (this.authorizationPromise && requiresAuth) await this.authorizationPromise;
 

--- a/src/youtube/BaseVideo/VideoCaptions.ts
+++ b/src/youtube/BaseVideo/VideoCaptions.ts
@@ -47,7 +47,7 @@ export class VideoCaptions extends Base {
 				(track: YoutubeRawData) =>
 					new CaptionLanguage({
 						captions: this,
-						name: track.name.simpleText,
+						name: track.name.simpleText || track.name.runs?.[0]?.text,
 						code: track.languageCode,
 						isTranslatable: !!track.isTranslatable,
 						url: track.baseUrl,
@@ -83,7 +83,7 @@ export class VideoCaptions extends Base {
 				new Caption({
 					duration: e.dDurationMs,
 					start: e.tStartMs,
-					text: e.segs?.map((s: YoutubeRawData) => s.utf8).join(),
+					text: e.segs?.map((s: YoutubeRawData) => s.utf8).join(""),
 					segments: e.segs,
 				})
 			);

--- a/src/youtube/Client/Client.ts
+++ b/src/youtube/Client/Client.ts
@@ -11,6 +11,8 @@ import {
 	INNERTUBE_API_KEY,
 	INNERTUBE_CLIENT_NAME,
 	INNERTUBE_CLIENT_VERSION,
+	INNERTUBE_PLAYER_CLIENT_NAME,
+	INNERTUBE_PLAYER_CLIENT_VERSION,
 	I_END_POINT,
 } from "../constants";
 
@@ -38,6 +40,8 @@ export class Client {
 			baseUrl: options.baseUrl || BASE_URL,
 			clientName: options.clientName || INNERTUBE_CLIENT_NAME,
 			clientVersion: options.clientVersion || INNERTUBE_CLIENT_VERSION,
+			playerClientName: options.playerClientName || INNERTUBE_PLAYER_CLIENT_NAME,
+			playerClientVersion: options.playerClientVersion || INNERTUBE_PLAYER_CLIENT_VERSION,
 		};
 
 		this.http = new HTTP(this.options);

--- a/src/youtube/constants.ts
+++ b/src/youtube/constants.ts
@@ -1,5 +1,8 @@
 export const INNERTUBE_CLIENT_NAME = "WEB";
 export const INNERTUBE_CLIENT_VERSION = "2.20260720.04.00";
+// WEB `/player` requests are rejected without a proof of origin token
+export const INNERTUBE_PLAYER_CLIENT_NAME = "IOS";
+export const INNERTUBE_PLAYER_CLIENT_VERSION = "20.10.4";
 export const INNERTUBE_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
 export const BASE_URL = "www.youtube.com";
 export const I_END_POINT = "/youtubei/v1";

--- a/tests/youtube/Captions.spec.ts
+++ b/tests/youtube/Captions.spec.ts
@@ -1,0 +1,60 @@
+import "jest-extended";
+
+import { Client, Video } from "../../src";
+
+const youtube = new Client({ youtubeClientOptions: { hl: "en" } });
+
+// Video with human-written captions in several languages
+const CAPTIONED_VIDEO_ID = "dQw4w9WgXcQ";
+// Video with auto-generated (asr) captions only
+const ASR_VIDEO_ID = "OX31kZbAXsA";
+
+describe("Captions", () => {
+	let video: Video;
+	let asrVideo: Video;
+
+	beforeAll(async () => {
+		video = (await youtube.getVideo(CAPTIONED_VIDEO_ID)) as Video;
+		asrVideo = (await youtube.getVideo(ASR_VIDEO_ID)) as Video;
+	});
+
+	it("parses caption tracks from the player response", () => {
+		expect(video.captions).not.toBeNull();
+		expect(video.captions!.languages.length).toBeGreaterThan(0);
+	});
+
+	it("exposes a name for every caption language", () => {
+		for (const language of video.captions!.languages) {
+			expect(typeof language.code).toBe("string");
+			expect(typeof language.name).toBe("string");
+		}
+	});
+
+	it("loads captions by language code", async () => {
+		const captions = await video.captions!.get("en");
+		expect(captions?.length).toBeGreaterThan(0);
+		expect(typeof captions![0].text).toBe("string");
+		expect(captions![0].end).toBe(captions![0].start + captions![0].duration);
+	});
+
+	it("falls back to the client hl when no language code is given", async () => {
+		const captions = await video.captions!.get();
+		expect(captions?.length).toBeGreaterThan(0);
+	});
+
+	it("loads captions through CaptionLanguage.get()", async () => {
+		const captions = await video.captions!.languages[0].get();
+		expect(captions?.length).toBeGreaterThan(0);
+	});
+
+	it("returns undefined for an unavailable language", async () => {
+		expect(await video.captions!.get("zz")).toBeUndefined();
+	});
+
+	it("joins multi-segment auto-generated captions without inserting commas", async () => {
+		const captions = await asrVideo.captions!.get("en");
+		const multiSegment = captions!.find((c) => c.segments.length > 1);
+		expect(multiSegment).toBeDefined();
+		expect(multiSegment!.text).toBe(multiSegment!.segments.map((s) => s.utf8).join(""));
+	});
+});


### PR DESCRIPTION
## What broke

`video.captions` is `undefined` on every video. `getVideoTranscript()` returns `undefined` for every video and language.

## Why

`getVideo` fires `/youtubei/v1/next` and `/youtubei/v1/player` in parallel, both as the `WEB` client. YouTube now rejects WEB player requests that don't carry a proof of origin token:

```json
{
  "playabilityStatus": {
    "status": "UNPLAYABLE",
    "reason": "Video unavailable",
    "errorScreen": { "...": "The page needs to be reloaded." }
  }
}
```

That response has no `captions` key and no `streamingData` key. `BaseVideoParser` only builds a `VideoCaptions` instance when `videoInfo.captions` is present, so the branch never runs and the field stays unset.

The `/next` call is unaffected, which is why titles, descriptions, comments and related videos all still work. Captions are the only thing that comes from `/player`, so they were the visible casualty.

A browser `User-Agent` and an `Origin` header do not help. The check is on the token, not the headers.

## Which clients still work

Same video, same request body, only the client identity changed:

| clientName | playabilityStatus | caption tracks |
|---|---|---|
| `WEB` (current default) | UNPLAYABLE | none |
| `MWEB` | UNPLAYABLE | none |
| `WEB_EMBEDDED_PLAYER` | ERROR | none |
| `TVHTML5_SIMPLY_EMBEDDED_PLAYER` | ERROR | none |
| `WEB_CREATOR` | LOGIN_REQUIRED | none |
| `ANDROID` | OK | 6 |
| `IOS` | OK | 6 |

## The fix

Send `/player` requests as `IOS` and leave every other endpoint on `WEB`. Two new constants sit next to the existing pair:

```ts
export const INNERTUBE_PLAYER_CLIENT_NAME = "IOS";
export const INNERTUBE_PLAYER_CLIENT_VERSION = "20.10.4";
```

`HTTPOptions` gains optional `playerClientName` and `playerClientVersion`, so callers can pick a different client or set both back to `WEB`. `HTTP.post` swaps the identity only when the path ends in `/player`. `MusicClient` never calls `/player` and is untouched.

When `pot` is set the swap is skipped, because a proof of origin token is exactly what makes the WEB client acceptable to `/player`. Existing token users keep their current behavior.

The `/player` path test was already written out in `request()`, so it moved into an `isPlayerEndpoint` helper that both call sites use.

## Two caption parser bugs the working response exposed

Neither could be reached before, since the parser never ran.

`VideoCaptions.load` read `track.name.simpleText`, but the payload carries `name.runs`, so every `CaptionLanguage.name` came back `undefined`. Now uses the same `simpleText || runs[0].text` form as `ChannelParser` and `PlaylistCompactParser`.

`VideoCaptions.get` called `.join()` with no separator, which defaults to a comma. Auto-generated captions carry one segment per word, so text came out as:

```
"you, guys, loved, our, last, video, using, a"
```

Now `.join("")`:

```
"you guys loved our last video using a"
```

## Also restored

`/player` supplies more than captions, so two other things start working again:

- `getVideo` returns `LiveVideo` for live streams. WEB stopped sending `playabilityStatus.liveStreamability`, so live videos were silently coming back as plain `Video`.
- `streamingData` is present, so `adaptiveFormats` is populated instead of always being an empty array.

## Tests

`tests/youtube/Captions.spec.ts` covers track parsing, language names, lookup by code, the `hl` fallback, `CaptionLanguage.get()`, an unknown language code, and the segment joining. All 7 pass.

Full suite: 35 pass, 2 fail. Both failures reproduce on `development` without this change and neither touches captions. One is a crash on `avatar.image` in `CommentParser`, the other is `LiveVideo.spec.ts` pointing at a video that is no longer live.

`tsc` passes on the main, cjs and esm configs. eslint and prettier are clean on the changed files.

## Note on longevity

This works today because `IOS` is not subject to the token check. If that changes, the same two options make it a one line swap to whichever client still answers, without another release of the library.
