### PR TITLE
fix comment parsing

### DIFF
--- a/src/common/utils/helper.ts
+++ b/src/common/utils/helper.ts
@@ -22,6 +22,17 @@ export const stripToInt = (string: string): number | null => {
 	return +string.replace(/[^0-9]/g, "");
 };
 
+// parses abbreviated counts such as "40K" or "1.2M"
+export const stripToIntCompact = (string: string): number | null => {
+	if (!string) return null;
+	const match = string.match(/([\d.,]+)\s*([KMB])?/i);
+	if (!match) return null;
+	const value = +match[1].replace(/,/g, "");
+	if (isNaN(value)) return null;
+	const multiplier: Record<string, number> = { k: 1e3, m: 1e6, b: 1e9 };
+	return Math.round(value * (multiplier[match[2]?.toLowerCase()] || 1));
+};
+
 export const getContinuationFromItems = (
 	items: YoutubeRawData,
 	accessors: string[] = ["continuationEndpoint"]

--- a/src/youtube/Comment/CommentParser.ts
+++ b/src/youtube/Comment/CommentParser.ts
@@ -1,20 +1,25 @@
-import { getContinuationFromItems, Thumbnails, YoutubeRawData } from "../../common";
+import {
+	getContinuationFromItems,
+	stripToIntCompact,
+	Thumbnails,
+	YoutubeRawData,
+} from "../../common";
 import { BaseChannel } from "../BaseChannel";
 import { Reply } from "../Reply";
 import { Comment } from "./Comment";
 
 export class CommentParser {
 	static loadComment(target: Comment, data: YoutubeRawData): Comment {
-		const { properties, toolbar, author, avatar } = data;
+		const { properties, toolbar, author } = data;
 
 		// Basic information
 		target.id = properties.commentId;
 		target.content = properties.content.content;
 		target.publishDate = properties.publishedTime;
-		target.likeCount = +toolbar.likeCountLiked; // probably broken
+		target.likeCount = stripToIntCompact(toolbar.likeCountLiked) || 0;
 		target.isAuthorChannelOwner = !!author.isCreator;
 		target.isPinned = false; // TODO fix this
-		target.replyCount = +toolbar.replyCount;
+		target.replyCount = stripToIntCompact(toolbar.replyCount) || 0;
 
 		// Reply Continuation
 		target.replies.continuation = data.replies
@@ -22,10 +27,14 @@ export class CommentParser {
 			: undefined;
 
 		// Author
+		const avatarUrl = author.avatarThumbnailUrl;
+		const avatarSize = +(avatarUrl?.match(/=s(\d+)/)?.[1] || 88);
 		target.author = new BaseChannel({
-			id: author.id,
+			id: author.channelId,
 			name: author.displayName,
-			thumbnails: new Thumbnails().load(avatar.image.sources),
+			thumbnails: new Thumbnails().load(
+				avatarUrl ? [{ url: avatarUrl, width: avatarSize, height: avatarSize }] : []
+			),
 			client: target.client,
 		});
 


### PR DESCRIPTION
`commentEntityPayload` changed shape, breaking `comments.next()` for every video.

- `avatar` is gone. The URL is now `author.avatarThumbnailUrl`, so reading `avatar.image.sources` threw and killed the whole call.
- `author.id` is now `author.channelId`, so every comment author had `id: undefined`.
- `toolbar.likeCountLiked` is abbreviated (`"40K"`), so `+value` was `NaN`. Added `stripToIntCompact` to parse it, also used for `replyCount`.

Fixes `Reply.spec.ts` and `Video.spec.ts > load video comments`, which both fail on `development`.
