### PR TITLE
fix shorts and abbreviated view count parsing

### DIFF
--- a/src/common/utils/helper.ts
+++ b/src/common/utils/helper.ts
@@ -22,6 +22,17 @@ export const stripToInt = (string: string): number | null => {
 	return +string.replace(/[^0-9]/g, "");
 };
 
+// parses abbreviated counts such as "40K" or "1.2M"
+export const stripToIntCompact = (string: string): number | null => {
+	if (!string) return null;
+	const match = string.match(/([\d.,]+)\s*([KMB])?/i);
+	if (!match) return null;
+	const value = +match[1].replace(/,/g, "");
+	if (isNaN(value)) return null;
+	const multiplier: Record<string, number> = { k: 1e3, m: 1e6, b: 1e9 };
+	return Math.round(value * (multiplier[match[2]?.toLowerCase()] || 1));
+};
+
 export const getContinuationFromItems = (
 	items: YoutubeRawData,
 	accessors: string[] = ["continuationEndpoint"]

--- a/src/youtube/BaseChannel/ChannelShorts.ts
+++ b/src/youtube/BaseChannel/ChannelShorts.ts
@@ -56,7 +56,7 @@ export class ChannelShorts extends Continuable<VideoCompact> {
 					channel: this.channel,
 				});
 				if (i.reelItemRenderer) video.load(i.reelItemRenderer);
-				else if (i.shortsLockupViewModel) video.loadLockup(i.lockupViewModel);
+				else if (i.shortsLockupViewModel) video.loadShortsLockup(i.shortsLockupViewModel);
 				return video;
 			}),
 		};

--- a/src/youtube/Comment/CommentParser.ts
+++ b/src/youtube/Comment/CommentParser.ts
@@ -1,20 +1,25 @@
-import { getContinuationFromItems, Thumbnails, YoutubeRawData } from "../../common";
+import {
+	getContinuationFromItems,
+	stripToIntCompact,
+	Thumbnails,
+	YoutubeRawData,
+} from "../../common";
 import { BaseChannel } from "../BaseChannel";
 import { Reply } from "../Reply";
 import { Comment } from "./Comment";
 
 export class CommentParser {
 	static loadComment(target: Comment, data: YoutubeRawData): Comment {
-		const { properties, toolbar, author, avatar } = data;
+		const { properties, toolbar, author } = data;
 
 		// Basic information
 		target.id = properties.commentId;
 		target.content = properties.content.content;
 		target.publishDate = properties.publishedTime;
-		target.likeCount = +toolbar.likeCountLiked; // probably broken
+		target.likeCount = stripToIntCompact(toolbar.likeCountLiked) || 0;
 		target.isAuthorChannelOwner = !!author.isCreator;
 		target.isPinned = false; // TODO fix this
-		target.replyCount = +toolbar.replyCount;
+		target.replyCount = stripToIntCompact(toolbar.replyCount) || 0;
 
 		// Reply Continuation
 		target.replies.continuation = data.replies
@@ -22,10 +27,14 @@ export class CommentParser {
 			: undefined;
 
 		// Author
+		const avatarUrl = author.avatarThumbnailUrl;
+		const avatarSize = +(avatarUrl?.match(/=s(\d+)/)?.[1] || 88);
 		target.author = new BaseChannel({
-			id: author.id,
+			id: author.channelId,
 			name: author.displayName,
-			thumbnails: new Thumbnails().load(avatar.image.sources),
+			thumbnails: new Thumbnails().load(
+				avatarUrl ? [{ url: avatarUrl, width: avatarSize, height: avatarSize }] : []
+			),
 			client: target.client,
 		});
 

--- a/src/youtube/VideoCompact/VideoCompact.ts
+++ b/src/youtube/VideoCompact/VideoCompact.ts
@@ -74,6 +74,16 @@ export class VideoCompact extends Base implements VideoCompactProperties {
 	}
 
 	/**
+	 * Load this instance with raw shorts lockup data from Youtube
+	 *
+	 * @hidden
+	 */
+	loadShortsLockup(data: YoutubeRawData): VideoCompact {
+		VideoCompactParser.loadShortsLockupVideoCompact(this, data);
+		return this;
+	}
+
+	/**
 	 * Get {@link Video} object based on current video id
 	 *
 	 * Equivalent to

--- a/src/youtube/VideoCompact/VideoCompactParser.ts
+++ b/src/youtube/VideoCompact/VideoCompactParser.ts
@@ -1,4 +1,11 @@
-import { getDuration, stripToInt, Thumbnails, YoutubeRawData } from "../../common";
+import {
+	getDuration,
+	getThumbnailFromId,
+	stripToInt,
+	stripToIntCompact,
+	Thumbnails,
+	YoutubeRawData,
+} from "../../common";
 import { BaseChannel } from "../BaseChannel";
 import { VideoCompact } from "./VideoCompact";
 
@@ -132,10 +139,26 @@ export class VideoCompactParser {
 		target.thumbnails = new Thumbnails().load(
 			data.contentImage.thumbnailViewModel.image.sources
 		);
-		target.viewCount = stripToInt(metadataRows[1].metadataParts[0].text.content);
+		target.viewCount = stripToIntCompact(metadataRows[1].metadataParts[0].text.content);
 		target.uploadDate = !isLive
 			? metadataRows[1].metadataParts[metadataRows[1].metadataParts.length - 1].text.content
 			: undefined;
+
+		return target;
+	}
+
+	static loadShortsLockupVideoCompact(target: VideoCompact, data: YoutubeRawData): VideoCompact {
+		const { reelWatchEndpoint } = data.onTap.innertubeCommand;
+		const { overlayMetadata } = data;
+
+		target.id = reelWatchEndpoint.videoId;
+		target.title = overlayMetadata?.primaryText?.content;
+		target.viewCount = stripToIntCompact(overlayMetadata?.secondaryText?.content);
+		target.thumbnails = new Thumbnails().load(
+			reelWatchEndpoint.thumbnail?.thumbnails || getThumbnailFromId(target.id)
+		);
+		target.duration = null;
+		target.isLive = false;
 
 		return target;
 	}


### PR DESCRIPTION
Two `VideoCompact` parsing bugs.

**Shorts throw.** `ChannelShorts` guards on `shortsLockupViewModel` but passes `lockupViewModel`, which is undefined, so `channel.shorts.next()` died on `data.metadata`. `shortsLockupViewModel` also has its own shape (`overlayMetadata`, `reelWatchEndpoint`) rather than the video lockup one, so it gets its own parser.

**Lockup view counts are off by orders of magnitude.** `stripToInt("6M views")` returns `6`, and `"8.2M views"` returns `82`. `video.related` was reporting 6 views for a 6M view video. Now uses `stripToIntCompact`.

Stacked on #162 for `stripToIntCompact`. Review the second commit only, or merge #162 first.
