### PR TITLE
return undefined for expired mix playlist

### DIFF
--- a/src/youtube/Client/Client.ts
+++ b/src/youtube/Client/Client.ts
@@ -89,7 +89,10 @@ export class Client {
 				data: { playlistId },
 			});
 
-			if (response.data.error) {
+			if (
+				response.data.error ||
+				!response.data.contents?.twoColumnWatchNextResults?.playlist
+			) {
 				return undefined as T;
 			}
 			return new MixPlaylist({ client: this }).load(response.data) as T;

--- a/tests/youtube/MixPlaylist.spec.ts
+++ b/tests/youtube/MixPlaylist.spec.ts
@@ -1,29 +1,25 @@
-// import { Client, MixPlaylist } from "../../src";
 import "jest-extended";
 
-// const youtube = new Client();
+import { Client, MixPlaylist } from "../../src";
 
-// NOTE: Seems like mix playlist doesn't lasts forever(?), making this test fails
+const youtube = new Client({ youtubeClientOptions: { hl: "en" } });
 
 describe("MixPlaylist", () => {
-	// let playlist: MixPlaylist;
-	// let invalidPlaylist: undefined;
-	// beforeAll(async () => {
-	// 	playlist = (await youtube.getPlaylist("RDjchDYHSBl_c")) as MixPlaylist;
-	// 	invalidPlaylist = (await youtube.getPlaylist("foo")) as undefined;
-	// });
-	// it("match getPlaylist result", () => {
-	// 	expect(playlist.id).toBe("RDjchDYHSBl_c");
-	// 	expect(playlist.title).toBe(
-	// 		"Mix - ElGrandeToto - Love Nwantiti (ft Ckay) (s l o w e d + r e v e r b)"
-	// 	);
-	// 	expect(playlist.videoCount).toBeGreaterThan(20);
-	// 	expect(playlist.videos.length).toBe(25);
-	// });
-	// it("match invalid getPlaylist", async () => {
-	// 	expect(invalidPlaylist).toBeUndefined();
-	// });
-	it("temporary", async () => {
-		expect(1).toBe(1);
+	let playlist: MixPlaylist;
+
+	beforeAll(async () => {
+		// mix ids expire, so derive one from a current search result
+		const result = await youtube.search("lofi", { type: "video" });
+		playlist = (await youtube.getPlaylist(`RD${result.items[0].id}`)) as MixPlaylist;
+	});
+
+	it("match getPlaylist result", () => {
+		expect(playlist instanceof MixPlaylist).toBeTrue();
+		expect(typeof playlist.title).toBe("string");
+		expect(playlist.videos.length).toBeGreaterThan(0);
+	});
+
+	it("match expired getPlaylist", async () => {
+		expect(await youtube.getPlaylist("RDjchDYHSBl_c")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
`getPlaylist` returns `undefined` for invalid ids, except for mixes. An expired mix responds 200 with no `error` and no `playlist` key, so `MixPlaylistParser` threw on `twoColumnWatchNextResults.playlist.playlist` instead.

Also restores `MixPlaylist.spec.ts`, which was commented out behind `expect(1).toBe(1)` because the pinned mix id had expired. It now derives a fresh id from a search result, so it won't rot again.
